### PR TITLE
Added changes for the swagger issue for UUID format

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -9,9 +9,6 @@ from django.contrib.auth.models import BaseUserManager, AbstractBaseUser
 
 USER_TYPE = (("Job Seeker", "User/Employee"), ("Employer", "HR/Employer"))
 
-def hex_uuid():
-    return uuid.uuid4().hex
-
 class UserManager(BaseUserManager):
     def create_user(self, email, name, user_type, password=None, password2=None):
         """
@@ -46,8 +43,8 @@ class UserManager(BaseUserManager):
 
 class User(AbstractBaseUser):
     
-    user_id = models.UUIDField(
-        primary_key=True, default=hex_uuid, editable=False, null=False, unique=True
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False, null=False, unique=True
     )
     email = models.EmailField(
         verbose_name="Email",

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -76,7 +76,7 @@ class GenerateToken:
 
    
 def OTP_DummyToken(user,purpose):
-    payload = {"email": user.email, "user_id": user.user_id.hex, "user_type": user.user_type}
+    payload = {"email": user.email, "user_id": str(user.id), "user_type": user.user_type}
     token = GenerateToken.generate_dummy_jwt_token(payload)
     
     # for old user
@@ -120,7 +120,7 @@ class UserRegistrationView(APIView):
 
         # Add an entry in the tbl_user_profile with dummy data
         dummy_data = {
-            "user_id": user.user_id.hex,
+            "user_id": user.id,
             "name" : user.name,
             "email": user.email,
             "user_type": user.user_type,

--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -13,11 +13,6 @@ STATUS_CHOICES = (
     ("on-hold", "On-Hold"),
 )
 
-
-def hex_uuid():
-    return uuid.uuid4().hex
-
-
 class Company(models.Model):
     """
     Represents a company with related details.
@@ -33,7 +28,7 @@ class Company(models.Model):
     location = models.CharField(max_length=255, null=False)
     about = models.TextField(max_length=500, default=None)
     company_id = models.UUIDField(
-        primary_key=True, default=hex_uuid, editable=False
+        primary_key=True, default=uuid.uuid4, editable=False
     )  # uuid1 uses network address for random number, so it's better to use uuid4
 
     def __str__(self):
@@ -52,7 +47,7 @@ class Job(models.Model):
         db_table = values.DB_TABLE_JOBS
 
     job_id = models.UUIDField(
-        primary_key=True, default=hex_uuid, editable=False, null=False
+        primary_key=True, default=uuid.uuid4, editable=False, null=False
     )
     job_role = models.CharField(max_length=100, null=False)
     company = models.ForeignKey(
@@ -97,7 +92,7 @@ class User(models.Model):
     )
     cover_letter = models.FileField(upload_to="cover_letter/", null=True)
     company = models.ForeignKey(Company, on_delete=models.CASCADE, null=True, default=None)
-    user_type = models.CharField(max_length=15, null=False, default=None)
+    user_type = models.CharField(max_length=15, default=None)
 
     def __str__(self):
         return self.name

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -16,18 +16,8 @@ from apps.jobs.models import Applicants, Company, Job, User
 # however at the time of crud opertions, it won't be present.
 
 
-class HexUUIDRepresentation(serializers.UUIDField):
-    def to_representation(self, value):
-        if isinstance(value, uuid.UUID):
-            return str(value.hex)
-        return super().to_representation(value)
-
-
 class JobSerializer(serializers.ModelSerializer):
     """Job object serializer class"""
-
-    job_id = HexUUIDRepresentation(read_only=True)
-    employer_id = HexUUIDRepresentation(read_only=False)
 
     class Meta:
         model = Job
@@ -37,8 +27,6 @@ class JobSerializer(serializers.ModelSerializer):
 class CompanySerializer(serializers.ModelSerializer):
     """Company object serializer class"""
 
-    company_id = HexUUIDRepresentation(read_only=True)
-
     class Meta:
         model = Company
         fields = "__all__"
@@ -47,8 +35,6 @@ class CompanySerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     """User object serializer class"""
 
-    user_id = HexUUIDRepresentation(read_only=True)
-
     class Meta:
         model = User
         fields = "__all__"
@@ -56,8 +42,6 @@ class UserSerializer(serializers.ModelSerializer):
 
 class ApplicantsSerializer(serializers.ModelSerializer):
     """Applicants object serializer class"""
-
-    employer_id = HexUUIDRepresentation(read_only=True)
 
     class Meta:
         model = Applicants

--- a/apps/jobs/utils/validators.py
+++ b/apps/jobs/utils/validators.py
@@ -12,13 +12,13 @@ class validationClass:
 
     @staticmethod
     def is_valid_uuid(value):
-        # Expects value in hex format of uuid, returns bool value
+        # Expects value in proper format(with hyphens) of uuid, returns bool value
         try:
             uuid_value = uuid.UUID(str(value))
         except ValueError:
             return False
         else:
-            return str(uuid_value.hex) == str(value)
+            return str(uuid_value) == str(value)
 
     @staticmethod
     def validate_id(uuid, idtype: str, model_class):


### PR DESCRIPTION
We were facing some issues in the Swagger UI when calling the endpoints to get the data for specific UUIDs.
Swagger UI doesn't accept UUID (without hyphens), because they strictly follow the standard made for UUID format. 

Read more about this on [here](https://github.com/swagger-api/swagger-ui/issues/5281)