### PR TITLE
AccessToken Expiration Fix

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -50,7 +50,7 @@ class TokenUtility:
     def generate_dummy_jwt_token(Cpayload):
         # creating custom payload with 5 minutes expiration time
         custom_payload = {
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
+            "exp": datetime.datetime.utcnow() + settings.SIMPLE_JWT['ACCESS_TOKEN_LIFETIME']
         }
         custom_payload.update(Cpayload)
         # Create a new AccessToken with the custom payload

--- a/null_jobs_backend/settings.py
+++ b/null_jobs_backend/settings.py
@@ -190,9 +190,9 @@ SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(days=365)
     if DISABLE_TOKEN_EXPIRATION
     else timedelta(minutes=3),
-    "REFRESH_TOKEN_LIFETIME": timedelta(minutes=5)
+    "REFRESH_TOKEN_LIFETIME": timedelta(minutes=365)
     if DISABLE_TOKEN_EXPIRATION
-    else timedelta(days=365),
+    else timedelta(days=5),
     "ROTATE_REFRESH_TOKENS": False,
     "BLACKLIST_AFTER_ROTATION": False,
     "CHECK_REVOKE_TOKEN": True,

--- a/null_jobs_backend/settings.py
+++ b/null_jobs_backend/settings.py
@@ -187,9 +187,9 @@ from datetime import timedelta
 DISABLE_TOKEN_EXPIRATION = False
 ENABLE_AUTHENTICATION = True
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=3)
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=365)
     if DISABLE_TOKEN_EXPIRATION
-    else timedelta(days=365),
+    else timedelta(minutes=3),
     "REFRESH_TOKEN_LIFETIME": timedelta(minutes=5)
     if DISABLE_TOKEN_EXPIRATION
     else timedelta(days=365),


### PR DESCRIPTION
Previously the JWT Expiration was set to 5 minutes, this time we are using the ACCESS_TOKEN_LIFETIME value which is defined in the settings.py under SIMPLE_JWT. The key's value set to 3 minutes only if the DISABLE_TOKEN_EXPIRATION is set to False. 