### PR TITLE
Trending keywords and authorization remove from jobs api

### DIFF
--- a/apps/jobs/constants/values.py
+++ b/apps/jobs/constants/values.py
@@ -22,6 +22,23 @@ JOB_TYPE = (
     ("internship", "INTERNSHIP"),
 )
 
+trending_keywords = [
+    "Research",
+    "Web Security",
+    "VA/PT",
+    "Management",
+    "Quality Assurance",
+    "Development",
+    "Consulting",
+    "Risk Assessment/Auditing",
+    "Mobile Pentesting",
+    "Security Engineer",
+    "Software Developer",
+    "Software Engineer",
+    "Malware Analyst",
+    "SOC Analyst"
+]
+
 EMPLOYER_ID = "employer_id"
 USER_ID = "user_id"
 JOB_ID = "job_id"

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -18,6 +18,9 @@ public_apis_jobs = [
     "/jobs/public_jobs/",
     "/jobs/get_jobs_categories/",
     "/jobs/get_jobs/",
+    "/jobs/featured_jobs/",
+    "/jobs/get_posted_jobs/",
+    ""
 ]
 
 # create a router

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -19,7 +19,8 @@ public_apis_jobs = [
     "/jobs/get_jobs_categories/",
     "/jobs/get_jobs/",
     "/jobs/featured_jobs/",
-    "/jobs/get_posted_jobs/"
+    "/jobs/get_posted_jobs/",
+    "/jobs/get_trending_keywords/"
 ]
 
 # create a router

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -19,8 +19,7 @@ public_apis_jobs = [
     "/jobs/get_jobs_categories/",
     "/jobs/get_jobs/",
     "/jobs/featured_jobs/",
-    "/jobs/get_posted_jobs/",
-    ""
+    "/jobs/get_posted_jobs/"
 ]
 
 # create a router

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -613,6 +613,23 @@ class JobViewSets(viewsets.ModelViewSet):
                 response.SOMETHING_WENT_WRONG, status.HTTP_400_BAD_REQUEST
             )
 
+    @action(detail=False, methods=["get"])
+    def get_trending_keywords(self, request):
+        """
+        API: /get_trending_keywords
+        This API returns a list of trending keywords
+        """
+
+        try:
+            return response.create_response(
+                {"trending_keywords": values.trending_keywords},
+                status.HTTP_200_OK
+            )
+        except Exception:
+            return response.create_response(
+                response.SOMETHING_WENT_WRONG,
+                status.HTTP_400_BAD_REQUEST
+            )
 
 class UserViewSets(viewsets.ModelViewSet):
     """


### PR DESCRIPTION
Temporary API introducted for "Trending keywords" Functionality:

Sample Request:
```curl
curl --location 'localhost:8000/jobs/get_trending_keywords/'
```

Sample Response:
```curl
{
    "data": {
        "trending_keywords": [
            "Research",
            "Web Security",
            "VA/PT",
            "Management",
            "Quality Assurance",
            "Development",
            "Consulting",
            "Risk Assessment/Auditing",
            "Mobile Pentesting",
            "Security Engineer",
            "Software Developer",
            "Software Engineer",
            "Malware Analyst",
            "SOC Analyst"
        ]
    }
}
```
