### PR TITLE
Added the fix for an error in /apply/job API

### DIFF
--- a/apps/applicants/views.py
+++ b/apps/applicants/views.py
@@ -54,8 +54,8 @@ class ApplyToJob(APIView):
         except Job.DoesNotExist:
             raise exceptions.NotFound()
         
-        application = Applicants.objects.first(job=job, user=user_profile)
-        if application is not None:
+        application = Applicants.objects.filter(job=job, user=user_profile)
+        if application.exists():
             return Response(
                 {"msg": "Already Applied!"},
                 status=status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
Error Description: 
Facing an "Internal Server Error" issue while applying for a job using `POST /apply/job/` API. Previously the parameters were passed to the `.first()` method, however it does not accept any parameters. Replaced it with `.filter()` method. 

API Request: 
```json
{
  "msg": "Created",
  "application_id": "a1204dbb-2146-4627-978a-e572ef59732f"
}
```

```json
{
  "msg": "Already Applied!"
}
```